### PR TITLE
[CLEANUP] Deprecate a bunch of classes

### DIFF
--- a/Classes/BackEnd/Ajax.php
+++ b/Classes/BackEnd/Ajax.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This class uses the new AJAX broker in TYPO3 4.2.
  *
- * @see http://bugs.typo3.org/view.php?id=7096
+ * @deprecated will be removed for PHPUnit 6.
  *
  * @author Kasper Ligaard <kasperligaard@gmail.com>
  * @author Michael Klapper <michael.klapper@aoemedia.de>

--- a/Classes/BackEnd/Module.php
+++ b/Classes/BackEnd/Module.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Lang\LanguageService;
 /**
  * Back-end module "PHPUnit".
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Kasper Ligaard <kasperligaard@gmail.com>
  * @author Michael Klapper <michael.klapper@aoemedia.de>
  * @author Oliver Klee <typo3-coding@oliverklee.de>

--- a/Classes/BackEnd/Request.php
+++ b/Classes/BackEnd/Request.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This class provides functions for reading data from a POST/GET request.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Phpunit_BackEnd_Request extends \Tx_Phpunit_AbstractDataContainer implements \Tx_Phpunit_Interface_Request, SingletonInterface

--- a/Classes/BackEnd/TestListener.php
+++ b/Classes/BackEnd/TestListener.php
@@ -21,6 +21,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This class renders the output of the single tests in the phpunit BE module.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Robert Lemke <robert@typo3.org>
  * @author Kasper Ligaard <kasperligaard@gmail.com>
  * @author Michael Klapper <michael.klapper@aoemedia.de>

--- a/Classes/BackEnd/TestStatistics.php
+++ b/Classes/BackEnd/TestStatistics.php
@@ -15,6 +15,8 @@
 /**
  * This class provides functions for measuring the time and memory usage of tests.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Phpunit_BackEnd_TestStatistics

--- a/Classes/BackEnd/index.php
+++ b/Classes/BackEnd/index.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * Module "PHPUnit".
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Kasper Ligaard <kasperligaard@gmail.com>
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */

--- a/Classes/Database/TestCase.php
+++ b/Classes/Database/TestCase.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Install\Service\SqlSchemaMigrationService;
 /**
  * Database testcase base class.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Michael Klapper <michael.klapper@aoemedia.de>
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */

--- a/Classes/FrontEnd/UserWithoutCookies.php
+++ b/Classes/FrontEnd/UserWithoutCookies.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 /**
  * This XCLASS makes sure no FE login cookies are sent during the unit tests.
+ *
+ * @deprecated will be removed for PHPUnit 6.
  */
 class Tx_Phpunit_FrontEnd_UserWithoutCookies extends FrontendUserAuthentication
 {

--- a/Classes/Selenium/TestCase.php
+++ b/Classes/Selenium/TestCase.php
@@ -19,6 +19,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * TYPO3. It extends \PHPUnit_Extensions_SeleniumTestCase, so you have access to
  * all of that class too.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Bastian Waidelich <bastian@typo3.org>
  * @author Carsten Koenig <ck@carsten-koenig.de>
  */

--- a/Classes/Service/FakeOutputService.php
+++ b/Classes/Service/FakeOutputService.php
@@ -15,6 +15,8 @@
 /**
  * This class serves as a stand-in for the real output service, e.g., for unit testing.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Phpunit_Service_FakeOutputService extends \Tx_Phpunit_Service_OutputService

--- a/Classes/Service/OutputService.php
+++ b/Classes/Service/OutputService.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Core\SingletonInterface;
 /**
  * This class provides functions for outputting content.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Phpunit_Service_OutputService implements SingletonInterface

--- a/Classes/Service/SeleniumService.php
+++ b/Classes/Service/SeleniumService.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * This class provides functions for using Selenium RC.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Felix Rauch <rauch@skaiamail.de>
  */
 class Tx_Phpunit_Service_SeleniumService implements \Tx_Phpunit_Interface_SeleniumService, SingletonInterface

--- a/Classes/ViewHelpers/AbstractSelectorViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSelectorViewHelper.php
@@ -15,6 +15,8 @@
 /**
  * This class is the base class for all view helpers which render some select boxes.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Nicole Cordes <nicole.cordes@googlemail.com>
  */
 abstract class Tx_Phpunit_ViewHelpers_AbstractSelectorViewHelper extends \Tx_Phpunit_ViewHelpers_AbstractTagViewHelper

--- a/Classes/ViewHelpers/AbstractTagViewHelper.php
+++ b/Classes/ViewHelpers/AbstractTagViewHelper.php
@@ -18,6 +18,8 @@
  * Should be used as the base class for all view helpers which output simple tags, as it provides some useful
  * convenience methods.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Felix Rauch <rauch@skaiamail.de>
  */
 abstract class Tx_Phpunit_ViewHelpers_AbstractTagViewHelper extends \Tx_Phpunit_ViewHelpers_AbstractViewHelper

--- a/Classes/ViewHelpers/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/AbstractViewHelper.php
@@ -16,6 +16,8 @@ use TYPO3\CMS\Lang\LanguageService;
 /**
  * This class is the base class for all view helpers.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 abstract class Tx_Phpunit_ViewHelpers_AbstractViewHelper

--- a/Classes/ViewHelpers/CheckboxViewHelper.php
+++ b/Classes/ViewHelpers/CheckboxViewHelper.php
@@ -15,6 +15,8 @@
 /**
  * This view helper renders an input field of type checkbox.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Felix Rauch <rauch@skaiamail.de>
  */
 class Tx_Phpunit_ViewHelpers_CheckboxViewHelper extends \Tx_Phpunit_ViewHelpers_AbstractTagViewHelper

--- a/Classes/ViewHelpers/ExtensionSelectorViewHelper.php
+++ b/Classes/ViewHelpers/ExtensionSelectorViewHelper.php
@@ -15,6 +15,8 @@
 /**
  * This view helper renders the extension selector box.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Nicole Cordes <nicole.cordes@googlemail.com>
  */
 class Tx_Phpunit_ViewHelpers_ExtensionSelectorViewHelper extends \Tx_Phpunit_ViewHelpers_AbstractSelectorViewHelper

--- a/Classes/ViewHelpers/ProgressBarViewHelper.php
+++ b/Classes/ViewHelpers/ProgressBarViewHelper.php
@@ -15,6 +15,8 @@
 /**
  * This view helper renders the progress bar.
  *
+ * @deprecated will be removed for PHPUnit 6.
+ *
  * @author Oliver Klee <typo3-coding@oliverklee.de>
  */
 class Tx_Phpunit_ViewHelpers_ProgressBarViewHelper extends \Tx_Phpunit_ViewHelpers_AbstractViewHelper


### PR DESCRIPTION
These classes are mostly needed for the BE module, database tests and
selenium tests (which will all be removed once TYPO3 8.7 is required).