### PR TITLE
[BUGFIX] Use getAbsoluteWebPath instead of extRelPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the incorrect TYPO3 Core license headers (#34)
 
 ### Fixed
+- Use getAbsoluteWebPath instead of extRelPath (#47)
 - Make the unit tests not depend on the current time of day (#36)
 - Provide cli_dispatch.phpsh for 8.7 on Travis (#33)
 

--- a/Classes/BackEnd/Module.php
+++ b/Classes/BackEnd/Module.php
@@ -6,8 +6,8 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * Back-end module "PHPUnit".
@@ -22,11 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Tx_Phpunit_BackEnd_Module extends BaseScriptClass
 {
-    /**
-     * @var string
-     */
-    const EXTENSION_KEY = 'phpunit';
-
     /**
      * @var string
      */
@@ -93,7 +88,7 @@ class Tx_Phpunit_BackEnd_Module extends BaseScriptClass
     {
         $this->init();
 
-        $this->extensionPath = ExtensionManagementUtility::extRelPath(self::EXTENSION_KEY);
+        $this->extensionPath = PathUtility::getAbsoluteWebPath('../typo3conf/ext/phpunit/');
     }
 
     /**

--- a/Classes/BackEnd/TestListener.php
+++ b/Classes/BackEnd/TestListener.php
@@ -3,8 +3,8 @@
 use SebastianBergmann\Comparator\ComparisonFailure;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\DiffUtility;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * This class renders the output of the single tests in the phpunit BE module.
@@ -526,7 +526,8 @@ class Tx_Phpunit_BackEnd_TestListener implements \PHPUnit_Framework_TestListener
     protected function createReRunLink(\PHPUnit_Framework_TestCase $test)
     {
         $iconImageTag = '<img class="runner" src="' .
-            ExtensionManagementUtility::extRelPath('phpunit') . 'Resources/Public/Icons/Runner.gif" alt="" />';
+            PathUtility::getAbsoluteWebPath('../typo3conf/ext/phpunit/Resources/Public/Icons/Runner.gif')
+             . '" alt="" />';
         return '<a href="' . $this->createReRunUrl($test) . '" title="Run this test only">' . $iconImageTag . '</a> ';
     }
 

--- a/Classes/Service/ExtensionSettingsService.php
+++ b/Classes/Service/ExtensionSettingsService.php
@@ -10,11 +10,6 @@ use TYPO3\CMS\Core\SingletonInterface;
 class Tx_Phpunit_Service_ExtensionSettingsService extends \Tx_Phpunit_AbstractDataContainer implements \Tx_Phpunit_Interface_ExtensionSettingsService, SingletonInterface
 {
     /**
-     * @var string
-     */
-    const EXTENSION_KEY = 'phpunit';
-
-    /**
      * @var array
      */
     private $cachedSettings = [];
@@ -51,8 +46,8 @@ class Tx_Phpunit_Service_ExtensionSettingsService extends \Tx_Phpunit_AbstractDa
      */
     protected function retrieveSettings()
     {
-        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::EXTENSION_KEY])) {
-            $this->cachedSettings = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::EXTENSION_KEY]);
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['phpunit'])) {
+            $this->cachedSettings = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['phpunit']);
         } else {
             $this->cachedSettings = [];
         }

--- a/Classes/Service/TestFinder.php
+++ b/Classes/Service/TestFinder.php
@@ -3,6 +3,7 @@
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * This class provides functions for finding test cases.
@@ -243,7 +244,8 @@ class Tx_Phpunit_Service_TestFinder implements SingletonInterface
         $possibleIconFileNames = ['ext_icon.gif', 'ext_icon.png'];
         foreach ($possibleIconFileNames as $fileNameCandidate) {
             if (file_exists(ExtensionManagementUtility::extPath($extensionKey) . $fileNameCandidate)) {
-                $testable->setIconPath(ExtensionManagementUtility::extRelPath($extensionKey) . $fileNameCandidate);
+                $iconPath = PathUtility::getAbsoluteWebPath('../typo3conf/ext/' . $extensionKey . '/' . $fileNameCandidate);
+                $testable->setIconPath($iconPath);
                 break;
             }
         }

--- a/Tests/Unit/BackEnd/ModuleTest.php
+++ b/Tests/Unit/BackEnd/ModuleTest.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Lang\LanguageService;
 
@@ -687,7 +688,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function createIconStyleForLoadedExtensionReturnsExtensionIcon()
     {
         self::assertContains(
-            'url(' . ExtensionManagementUtility::extRelPath('phpunit') . 'ext_icon.png)',
+            'url(' . PathUtility::getAbsoluteWebPath('../typo3conf/ext/phpunit/ext_icon.png') . ')',
             $this->subject->createIconStyle('phpunit')
         );
     }
@@ -795,7 +796,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $this->userSettingsService->set('extSel', $selectedExtension);
 
         self::assertContains(
-            'background: url(' . ExtensionManagementUtility::extRelPath('phpunit') . 'ext_icon.png)',
+            'background: url(' . PathUtility::getAbsoluteWebPath('../typo3conf/ext/phpunit/ext_icon.png') . ')',
             $this->subject->createTestCaseSelector($selectedExtension)
         );
     }

--- a/Tests/Unit/Service/TestFinderTest.php
+++ b/Tests/Unit/Service/TestFinderTest.php
@@ -3,6 +3,7 @@ namespace OliverKlee\Phpunit\Tests\Unit\Service;
 
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
  * Test case.
@@ -810,7 +811,7 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         /** @var \Tx_Phpunit_Testable $testable */
         $testable = array_pop($testables);
         self::assertSame(
-            ExtensionManagementUtility::extRelPath('user_phpunittest') . 'ext_icon.gif',
+            PathUtility::getAbsoluteWebPath('../typo3conf/ext/user_phpunittest/ext_icon.gif'),
             $testable->getIconPath()
         );
     }
@@ -834,7 +835,7 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         /** @var \Tx_Phpunit_Testable $testable */
         $testable = array_pop($testables);
         self::assertSame(
-            ExtensionManagementUtility::extRelPath('phpunit') . 'ext_icon.png',
+            PathUtility::getAbsoluteWebPath('../typo3conf/ext/phpunit/ext_icon.png'),
             $testable->getIconPath()
         );
     }

--- a/Tests/Unit/ViewHelpers/ExtensionSelectorViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/ExtensionSelectorViewHelperTest.php
@@ -2,6 +2,7 @@
 namespace OliverKlee\Phpunit\Tests\Unit\ViewHelpers;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Lang\LanguageService;
 
@@ -190,7 +191,7 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $extensionKey = 'phpunit';
         $testable = new \Tx_Phpunit_Testable();
         $testable->setKey($extensionKey);
-        $testable->setIconPath(ExtensionManagementUtility::extRelPath($extensionKey) . 'ext_icon.gif');
+        $testable->setIconPath(PathUtility::getAbsoluteWebPath('../typo3conf/ext/' . $extensionKey . '/ext_icon.gif'));
 
         $subject = new \Tx_Phpunit_ViewHelpers_ExtensionSelectorViewHelper();
         $subject->injectOutputService($this->outputService);
@@ -218,7 +219,7 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $extensionKey = 'phpunit';
         $testable = new \Tx_Phpunit_Testable();
         $testable->setKey($extensionKey);
-        $testable->setIconPath(ExtensionManagementUtility::extRelPath($extensionKey) . 'ext_icon.gif');
+        $testable->setIconPath(PathUtility::getAbsoluteWebPath('../typo3conf/ext/' . $extensionKey . '/ext_icon.gif'));
 
         $subject = new \Tx_Phpunit_ViewHelpers_ExtensionSelectorViewHelper();
         $subject->injectOutputService($this->outputService);
@@ -246,12 +247,12 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $extensionKey1 = 'phpunit';
         $testable1 = new \Tx_Phpunit_Testable();
         $testable1->setKey($extensionKey1);
-        $testable1->setIconPath(ExtensionManagementUtility::extRelPath($extensionKey1) . 'ext_icon.gif');
+        $testable1->setIconPath(PathUtility::getAbsoluteWebPath('../typo3conf/ext/' . $extensionKey1 . '/ext_icon.gif'));
 
         $extensionKey2 = 'core';
         $testable2 = new \Tx_Phpunit_Testable();
         $testable2->setKey($extensionKey2);
-        $testable1->setIconPath(ExtensionManagementUtility::extRelPath($extensionKey2) . 'ext_icon.gif');
+        $testable2->setIconPath(PathUtility::getAbsoluteWebPath('../typo3conf/ext/' . $extensionKey2 . '/ext_icon.gif'));
 
         $subject = new \Tx_Phpunit_ViewHelpers_ExtensionSelectorViewHelper();
         $subject->injectOutputService($this->outputService);


### PR DESCRIPTION
extRelPath is deprecated in TYPO3 8.7.