### PR TITLE
[BUGFIX] Use the DB name from the connection pool in TYPO3 >= 8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Use the DB name from the connection pool in TYPO3 >= 8.7 (#58, #55)
 - Hide the test tables from BE user table permission lists (#52)
 - Simplify the fake frontend teardown (#51)
 

--- a/Classes/Database/TestCase.php
+++ b/Classes/Database/TestCase.php
@@ -35,7 +35,15 @@ abstract class Tx_Phpunit_Database_TestCase extends \Tx_Phpunit_TestCase
     public function __construct($name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
-        $this->testDatabase = strtolower(TYPO3_db . '_test');
+        /** @var array $databaseConfiguration */
+        $databaseConfiguration = $GLOBALS['TYPO3_CONF_VARS']['DB'];
+        if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) >= 8001000) {
+            $originalDatabaseName = $databaseConfiguration['Connections']['Default']['dbname'];
+        } else {
+            $originalDatabaseName = $databaseConfiguration['database'];
+        }
+
+        $this->testDatabase = strtolower($originalDatabaseName . '_test');
     }
 
     /**


### PR DESCRIPTION
Fixes #55