### PR TITLE
[TASK] Drop the direct phpunit/phpunit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecate Tx_Phpunit_Service_Database (#76)
 
 ### Removed
+- Drop the direct phpunit/phpunit dependency (#90)
 - Remove the unused PHPUnit configuration file (#76)
 - Remove the obsolete ext_autoload.php (#56)
 

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,7 @@
         "oliverklee/user-phpunittest2": "@dev",
 
         "typo3/cms-frontend": "^7.6.23 || ^8.7.9",
-        "helhum/typo3-console": "^4.9",
-
-        "phpunit/phpunit": "~5.3.0",
-        "phpunit/phpunit-selenium": "^3.0.0",
-        "mikey179/vfsstream": "^1.6"
+        "helhum/typo3-console": "^4.9"
     },
     "replace": {
         "typo3-ter/phpunit": "self.version"


### PR DESCRIPTION
`phpunit/phpunit`, `phpunit/phpunit-selenium` and
`mikey179/vfsstream` should not be included as a dev dependency,
but only by the LibraryIncluder in the test runners.

This helps detect problems with the test runners when running the
tests for the phpunit extension itself.