### PR TITLE
[CLEANUP] Replace usage of deprecated PHPUnit API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Auto-release to the TER (#67)
 
 ### Changed
-- Update PHPUnit to 5.7 (#93)
+- Update PHPUnit to 5.7 (#93, #94)
 - Stop using a PHAR for including libraries (#87)
 - Use spaces for indenting SQL and .htaccess files (#78)
 - Streamline ext_emconf.php (#74, #75)

--- a/Classes/TestCase.php
+++ b/Classes/TestCase.php
@@ -37,7 +37,6 @@ abstract class Tx_Phpunit_TestCase extends \PHPUnit_Framework_TestCase
      * @param string $mockClassName the class name to use for the mock class
      * @param bool $callOriginalConstructor whether to call the constructor
      * @param bool $callOriginalClone whether to call the __clone method
-     * @param bool $callAutoload whether to call any autoload function
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|\Tx_Phpunit_Interface_AccessibleObject
      *         a mock of $originalClassName with access methods added
@@ -50,22 +49,22 @@ abstract class Tx_Phpunit_TestCase extends \PHPUnit_Framework_TestCase
         array $arguments = [],
         $mockClassName = '',
         $callOriginalConstructor = true,
-        $callOriginalClone = true,
-        $callAutoload = true
+        $callOriginalClone = true
     ) {
         if ($originalClassName === '') {
             throw new \InvalidArgumentException('$originalClassName must not be empty.', 1334701880);
         }
 
-        return $this->getMock(
-            $this->buildAccessibleProxy($originalClassName),
-            $methods,
-            $arguments,
-            $mockClassName,
-            $callOriginalConstructor,
-            $callOriginalClone,
-            $callAutoload
-        );
+        $mockBuilder = $this->getMockBuilder($this->buildAccessibleProxy($originalClassName))
+            ->setMethods($methods)->setConstructorArgs($arguments)->setMockClassName($mockClassName);
+        if (!$callOriginalConstructor) {
+            $mockBuilder->disableOriginalConstructor();
+        }
+        if (!$callOriginalClone) {
+            $mockBuilder->disableOriginalClone();
+        }
+
+        return $mockBuilder->getMock();
     }
 
     /**

--- a/Tests/Functional/Service/UserSettingsServiceTest.php
+++ b/Tests/Functional/Service/UserSettingsServiceTest.php
@@ -43,7 +43,7 @@ class UserSettingsServiceTest extends \Tx_Phpunit_TestCase
             self::markTestSkipped('The BE module is not available in TYPO3 CMS >= 8.');
         }
 
-        $GLOBALS['BE_USER'] = $this->getMock(BackendUserAuthentication::class);
+        $GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
 
         $this->subject = new \Tx_Phpunit_Service_UserSettingsService();
 

--- a/Tests/Unit/BackEnd/AjaxTest.php
+++ b/Tests/Unit/BackEnd/AjaxTest.php
@@ -59,7 +59,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['state'] = '1';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $this->subject->ajaxBroker([], $ajax);
 
         self::assertTrue(
@@ -75,7 +75,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'failure';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $this->subject->ajaxBroker([], $ajax);
 
         self::assertFalse(
@@ -91,7 +91,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'failure';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -106,7 +106,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'success';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -121,7 +121,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'error';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -136,7 +136,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'skipped';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -151,7 +151,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'incomplete';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -166,7 +166,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'testdox';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -181,7 +181,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'codeCoverage';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -196,7 +196,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'showTime';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -211,7 +211,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'runSeleniumTests';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('addContent')->with('success', true);
         $ajax->expects(self::never())->method('setError');
 
@@ -224,7 +224,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
     public function ajaxBrokerForMissingCheckboxParameterSetsError()
     {
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('setError');
 
         $this->subject->ajaxBroker([], $ajax);
@@ -238,7 +238,7 @@ class AjaxTest extends \Tx_Phpunit_TestCase
         $GLOBALS['_POST']['checkbox'] = 'anything else';
 
         /** @var AjaxRequestHandler|\PHPUnit_Framework_MockObject_MockObject $ajax */
-        $ajax = $this->getMock(AjaxRequestHandler::class, [], ['']);
+        $ajax = $this->createMock(AjaxRequestHandler::class);
         $ajax->expects(self::once())->method('setError');
 
         $this->subject->ajaxBroker([], $ajax);

--- a/Tests/Unit/BackEnd/ModuleTest.php
+++ b/Tests/Unit/BackEnd/ModuleTest.php
@@ -114,10 +114,10 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $this->testCaseService->injectUserSettingsService($this->userSettingsService);
         $this->subject->injectTestCaseService($this->testCaseService);
 
-        $this->progressBarViewHelper = $this->getMock(\Tx_Phpunit_ViewHelpers_ProgressBarViewHelper::class);
+        $this->progressBarViewHelper = $this->createMock(\Tx_Phpunit_ViewHelpers_ProgressBarViewHelper::class);
         GeneralUtility::addInstance(\Tx_Phpunit_ViewHelpers_ProgressBarViewHelper::class, $this->progressBarViewHelper);
 
-        $this->documentTemplate = $this->getMock(DocumentTemplate::class, ['startPage']);
+        $this->documentTemplate = $this->getMockBuilder(DocumentTemplate::class)->setMethods(['startPage'])->getMock();
         GeneralUtility::addInstance(DocumentTemplate::class, $this->documentTemplate);
 
         $this->singletonInstances = GeneralUtility::getSingletonInstances();
@@ -228,7 +228,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $GLOBALS['BE_USER']->user['admin'] = false;
 
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_Module::class, ['renderRunTests']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_Module::class)->setMethods(['renderRunTests'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         $subject->expects(self::never())->method('renderRunTests');
@@ -244,7 +244,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $GLOBALS['BE_USER']->user['admin'] = true;
 
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTests']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunningTest', 'renderRunTests'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectUserSettingsService($this->userSettingsService);
@@ -259,7 +260,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForEmptyCommandRendersIntro()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -280,7 +282,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForEmptyCommandNotRunsTests()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -301,7 +304,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForInvalidCommandRendersIntro()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -322,7 +326,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForInvalidCommandNotRunsTests()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -343,7 +348,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForRunAllTestsCommandRendersIntroAndTests()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -365,7 +371,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForRunTestCaseFileCommandRendersIntroAndTests()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -387,7 +394,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsForRunSingleTestCommandRendersIntroAndTests()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['renderRunTestsIntro', 'renderRunningTest']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['renderRunTestsIntro', 'renderRunningTest'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -409,16 +417,16 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsIntroForNoExtensionsWithTestSuitesShowsErrorMessage()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(
+                ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
+            )->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class);
-        $testFinder->expects(self::any())->method('existsTestableForAnything')->will(self::returnValue(false));
+        $testFinder = $this->createMock(\Tx_Phpunit_Service_TestFinder::class);
+        $testFinder->method('existsTestableForAnything')->willReturn(false);
         $subject->injectTestFinder($testFinder);
 
         $this->userSettingsService->set('extSel', 'phpunit');
@@ -438,17 +446,17 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsIntroForNoExtensionsWithTestSuitesNotRendersExtensionSelector()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(
+                ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
+            )->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class);
-        $testFinder->expects(self::any())->method('existsTestableForAnything')->will(self::returnValue(false));
+        $testFinder = $this->createMock(\Tx_Phpunit_Service_TestFinder::class);
+        $testFinder->method('existsTestableForAnything')->willReturn(false);
         $subject->injectTestFinder($testFinder);
 
         $this->userSettingsService->set('extSel', 'phpunit');
@@ -465,10 +473,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
     public function renderRunTestsIntroForExistingExtensionsWithTestSuitesRendersExtensionSelector()
     {
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['createExtensionSelector'])->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
 
@@ -490,10 +496,10 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $selectedExtension = 'phpunit';
 
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(
+                ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
+            )->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -502,7 +508,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingsService($this->userSettingsService);
 
         $subject->expects(self::once())->method('createTestCaseSelector')
-            ->with($selectedExtension)->will(self::returnValue('test case selector'));
+            ->with($selectedExtension)->willReturn('test case selector');
 
         $subject->renderRunTestsIntro();
 
@@ -520,10 +526,10 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $selectedExtension = 'phpunit';
 
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(
+                ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
+            )->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -532,7 +538,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingsService($this->userSettingsService);
 
         $subject->expects(self::once())->method('createTestSelector')
-            ->with($selectedExtension)->will(self::returnValue('test selector'));
+            ->with($selectedExtension)->willReturn('test selector');
 
         $subject->renderRunTestsIntro();
 
@@ -550,10 +556,10 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $selectedExtension = 'phpunit';
 
         /** @var \Tx_Phpunit_BackEnd_Module|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            $this->createAccessibleProxy(),
-            ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
-        );
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(
+                ['createExtensionSelector', 'createTestCaseSelector', 'createCheckboxes', 'createTestSelector']
+            )->getMock();
         $subject->injectRequest($this->request);
         $subject->injectOutputService($this->outputService);
         $subject->injectTestFinder($this->testFinder);
@@ -562,7 +568,7 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingsService($this->userSettingsService);
 
         $subject->expects(self::once())->method('createTestSelector')
-            ->with($selectedExtension)->will(self::returnValue('test selector'));
+            ->with($selectedExtension)->willReturn('test selector');
 
         $subject->renderRunTestsIntro();
 
@@ -597,7 +603,8 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $directory = 'vfs://Foo/';
 
         /** @var \Tx_Phpunit_Service_TestCaseService|\PHPUnit_Framework_MockObject_MockObject $testCaseService */
-        $testCaseService = $this->getMock(\Tx_Phpunit_Service_TestCaseService::class, ['findTestCaseFilesInDirectory']);
+        $testCaseService = $this->getMockBuilder(\Tx_Phpunit_Service_TestCaseService::class)
+            ->setMethods(['findTestCaseFilesInDirectory'])->getMock();
         $testCaseService->expects(self::once())->method('findTestCaseFilesInDirectory')->with($directory);
         $this->subject->injectTestCaseService($testCaseService);
 
@@ -615,10 +622,11 @@ class ModuleTest extends \Tx_Phpunit_TestCase
         $testFiles = ['class.testOneTest.php', 'class.testTwoTest.php'];
 
         /** @var \Tx_Phpunit_Service_TestCaseService|\PHPUnit_Framework_MockObject_MockObject $testCaseService */
-        $testCaseService = $this->getMock(\Tx_Phpunit_Service_TestCaseService::class, ['findTestCaseFilesInDirectory']);
+        $testCaseService = $this->getMockBuilder(\Tx_Phpunit_Service_TestCaseService::class)
+            ->setMethods(['findTestCaseFilesInDirectory'])->getMock();
         $testCaseService->expects(self::once())
             ->method('findTestCaseFilesInDirectory')
-            ->will(self::returnValue($testFiles));
+            ->willReturn($testFiles);
         $this->subject->injectTestCaseService($testCaseService);
 
         self::assertSame(

--- a/Tests/Unit/BackEnd/TestListenerTest.php
+++ b/Tests/Unit/BackEnd/TestListenerTest.php
@@ -128,9 +128,10 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function addFailureOutputsTestName()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         /** @var \PHPUnit_Framework_AssertionFailedError|\PHPUnit_Framework_MockObject_MockObject $error */
-        $error = $this->getMock(\PHPUnit_Framework_AssertionFailedError::class);
+        $error = $this->createMock(\PHPUnit_Framework_AssertionFailedError::class);
         $time = 0.0;
 
         $this->subject->addFailure($testCase, $error, $time);
@@ -149,7 +150,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testName = '<b>b</b>';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], [$testName]);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs([$testName])->getMock();
         $time = 0.0;
 
         $this->subject->addError($testCase, new \Exception(), $time);
@@ -172,9 +174,10 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testName = '<b>b</b>';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], [$testName]);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs([$testName])->getMock();
         /** @var \PHPUnit_Framework_AssertionFailedError|\PHPUnit_Framework_MockObject_MockObject $error */
-        $error = $this->getMock(\PHPUnit_Framework_AssertionFailedError::class);
+        $error = $this->createMock(\PHPUnit_Framework_AssertionFailedError::class);
         $time = 0.0;
 
         $this->subject->addFailure($testCase, $error, $time);
@@ -199,7 +202,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         }
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $error = new \PHPUnit_Framework_ExpectationFailedException(
             '',
             new ComparisonFailure(
@@ -225,7 +229,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function addFailureWithComparisonFailureForTwoStringsOutputsHtmlSpecialcharedActualString()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $error = new \PHPUnit_Framework_ExpectationFailedException(
             '',
             new ComparisonFailure(
@@ -251,7 +256,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function addFailureWithComparisonFailureForTwoStringsDoesNotCrash()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $error = new \PHPUnit_Framework_ExpectationFailedException(
             '',
             new ComparisonFailure(
@@ -272,7 +278,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function addFailureWithNullComparisonFailureDoesNotCrash()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $error = new \PHPUnit_Framework_ExpectationFailedException('', null);
         $time = 0.0;
 
@@ -287,7 +294,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testName = 'a<b>Test</b>Name';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], [$testName]);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs([$testName])->getMock();
         $exception = new \Exception();
         $time = 0.0;
 
@@ -311,7 +319,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $message = 'a<b>Test</b>Name';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $exception = new \Exception($message);
         $time = 0.0;
 
@@ -335,7 +344,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testName = 'a<b>Test</b>Name';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], [$testName]);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs([$testName])->getMock();
         $exception = new \Exception();
         $time = 0.0;
 
@@ -359,7 +369,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $message = 'a<b>Test</b>Name';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $exception = new \Exception($message);
         $time = 0.0;
 
@@ -381,13 +392,15 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function startTestSuiteOutputsPrettifiedTestClassName()
     {
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['prettifyTestClass']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['prettifyTestClass'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         /** @var \PHPUnit_Framework_TestSuite|\PHPUnit_Framework_MockObject_MockObject $testSuite */
-        $testSuite = $this->getMock(\PHPUnit_Framework_TestSuite::class, ['run'], ['aTestSuiteName']);
+        $testSuite = $this->getMockBuilder(\PHPUnit_Framework_TestSuite::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestSuiteName'])->getMock();
         $subject->expects(self::once())->method('prettifyTestClass')
-            ->with('aTestSuiteName')->will(self::returnValue('a test suite name'));
+            ->with('aTestSuiteName')->willReturn('a test suite name');
 
         $subject->startTestSuite($testSuite);
 
@@ -403,7 +416,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestSuiteCanBeCalled()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $testSuite */
-        $testSuite = $this->getMock(\PHPUnit_Framework_TestSuite::class);
+        $testSuite = $this->createMock(\PHPUnit_Framework_TestSuite::class);
 
         $this->subject->endTestSuite($testSuite);
     }
@@ -414,13 +427,14 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function startTestSetsTimeLimitOf240Seconds()
     {
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['setTimeLimit']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['setTimeLimit'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         $subject->expects(self::once())->method('setTimeLimit')->with(240);
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class);
+        $testCase = $this->createMock(\PHPUnit_Framework_TestCase::class);
         $subject->startTest($testCase);
     }
 
@@ -430,14 +444,15 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function startTestOutputsCurrentTestNumberAndDataProviderNumberAsHtmlId()
     {
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['setTimeLimit']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())
+            ->setMethods(['setTimeLimit'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         $subject->setTestNumber(42);
         $subject->setDataProviderNumber(91);
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class);
+        $testCase = $this->createMock(\PHPUnit_Framework_TestCase::class);
         $subject->startTest($testCase);
 
         self::assertContains(
@@ -452,13 +467,14 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function startTestOutputsReRunLink()
     {
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['setTimeLimit', 'createReRunLink']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['setTimeLimit', 'createReRunLink'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class);
+        $testCase = $this->createMock(\PHPUnit_Framework_TestCase::class);
         $subject->expects(self::once())->method('createReRunLink')
-            ->with($testCase)->will(self::returnValue('the re-run URL'));
+            ->with($testCase)->willReturn('the re-run URL');
 
         $subject->startTest($testCase);
 
@@ -474,13 +490,15 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function startTestOutputsPrettifiedTestName()
     {
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['setTimeLimit', 'prettifyTestMethod']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['setTimeLimit', 'prettifyTestMethod'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], ['aTestName']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs(['aTestName'])->getMock();
         $subject->expects(self::once())->method('prettifyTestMethod')
-            ->with('aTestName')->will(self::returnValue('a test name'));
+            ->with('aTestName')->willReturn('a test name');
 
         $subject->startTest($testCase);
 
@@ -498,15 +516,17 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testName = '<b>b</b>';
 
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['setTimeLimit', 'prettifyTestMethod']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['setTimeLimit', 'prettifyTestMethod'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['run'], [$testName]);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['run'])->setConstructorArgs([$testName])->getMock();
         $subject->expects(self::once())
             ->method('prettifyTestMethod')
             ->with($testName)
-            ->will(self::returnValue($testName));
+            ->willReturn($testName);
 
         $subject->startTest($testCase);
 
@@ -528,13 +548,15 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $testSuiteName = '<b>b</b>';
 
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_BackEnd_TestListener::class, ['prettifyTestClass']);
+        $subject = $this->getMockBuilder(\Tx_Phpunit_BackEnd_TestListener::class)
+            ->setMethods(['prettifyTestClass'])->getMock();
         $subject->injectOutputService($this->outputService);
 
         /** @var \PHPUnit_Framework_TestSuite|\PHPUnit_Framework_MockObject_MockObject $testSuite */
-        $testSuite = $this->getMock(\PHPUnit_Framework_TestSuite::class, ['run'], [$testSuiteName]);
+        $testSuite = $this->getMockBuilder(\PHPUnit_Framework_TestSuite::class)
+            ->setMethods(['run'])->setConstructorArgs([$testSuiteName])->getMock();
         $subject->expects(self::once())->method('prettifyTestClass')
-            ->with($testSuiteName)->will(self::returnValue($testSuiteName));
+            ->with($testSuiteName)->willReturn($testSuiteName);
 
         $subject->startTestSuite($testSuite);
 
@@ -554,8 +576,9 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestAddsTestAssertionsToTotalAssertionCount()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase1 */
-        $testCase1 = $this->getMock(\PHPUnit_Framework_TestCase::class, ['getNumAssertions']);
-        $testCase1->expects(self::once())->method('getNumAssertions')->will(self::returnValue(1));
+        $testCase1 = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['getNumAssertions'])->getMock();
+        $testCase1->expects(self::once())->method('getNumAssertions')->willReturn(1);
 
         $this->subject->endTest($testCase1, 0.0);
         self::assertSame(
@@ -565,8 +588,9 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         );
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase2 */
-        $testCase2 = $this->getMock(\PHPUnit_Framework_TestCase::class, ['getNumAssertions']);
-        $testCase2->expects(self::once())->method('getNumAssertions')->will(self::returnValue(4));
+        $testCase2 = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['getNumAssertions'])->getMock();
+        $testCase2->expects(self::once())->method('getNumAssertions')->willReturn(4);
 
         $this->subject->endTest($testCase2, 0.0);
         self::assertSame(
@@ -582,7 +606,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestForTestCaseInstanceLeavesAssertionCountUnchanged()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class);
+        $testCase = $this->createMock(\PHPUnit_Framework_TestCase::class);
 
         $this->subject->endTest($testCase, 0.0);
         self::assertSame(
@@ -597,7 +621,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestForPlainTestInstanceLeavesAssertionCountUnchanged()
     {
         /** @var \PHPUnit_Framework_Test|\PHPUnit_Framework_MockObject_MockObject $test */
-        $test = $this->getMock(\PHPUnit_Framework_Test::class);
+        $test = $this->createMock(\PHPUnit_Framework_Test::class);
 
         $this->subject->endTest($test, 0.0);
         self::assertSame(
@@ -612,9 +636,11 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestIncreasesTotalNumberOfDataProvidedTestsWhenRunWithDataProvidedTests()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $test */
-        $test = $this->getMock(\PHPUnit_Framework_TestCase::class, ['dummy'], ['Test 1']);
+        $test = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setMethods(['dummy'])
+            ->setConstructorArgs(['Test 1'])->getMock();
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $test2 */
-        $test2 = $this->getMock(\PHPUnit_Framework_TestCase::class, ['dummy'], ['Test 2']);
+        $test2 = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setMethods(['dummy'])
+            ->setConstructorArgs(['Test 2'])->getMock();
 
         $this->subject->endTest($test, 0.0);
         $this->subject->endTest($test2, 0.0);
@@ -631,9 +657,11 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function endTestDoesNotIncreaseTotalNumberOfDataProvidedTestsWhenRunWithNormalTests()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, ['dummy'], ['FirstTest']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['dummy'])->setConstructorArgs(['FirstTest'])->getMock();
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase2 */
-        $testCase2 = $this->getMock(\PHPUnit_Framework_TestCase::class, ['dummy'], ['SecondTest']);
+        $testCase2 = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)
+            ->setMethods(['dummy'])->setConstructorArgs(['SecondTest'])->getMock();
 
         $this->subject->endTest($testCase, 0.0);
         $this->subject->endTest($testCase2, 0.0);
@@ -652,12 +680,13 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $reRunUrl = 'index.php?reRun=1&amp;foo=bar';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])
+            ->getMock();
 
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['createReRunUrl']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())->setMethods(['createReRunUrl'])->getMock();
         $subject->expects(self::once())->method('createReRunUrl')
-            ->will(self::returnValue($reRunUrl));
+            ->willReturn($reRunUrl);
 
         self::assertContains(
             '<a href="' . $reRunUrl . '"',
@@ -673,12 +702,13 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $reRunUrl = 'index.php?reRun=1&amp;foo=bar';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])
+            ->getMock();
 
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['createReRunUrl']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())->setMethods(['createReRunUrl'])->getMock();
         $subject->expects(self::once())->method('createReRunUrl')
-            ->will(self::returnValue($reRunUrl));
+            ->willReturn($reRunUrl);
 
         self::assertContains(
             '</a> ',
@@ -694,12 +724,13 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
         $reRunUrl = 'index.php?reRun=1&amp;foo=bar';
 
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_MockObject_MockObject $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])
+            ->getMock();
 
         /** @var \Tx_Phpunit_BackEnd_TestListener|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock($this->createAccessibleProxy(), ['createReRunUrl']);
+        $subject = $this->getMockBuilder($this->createAccessibleProxy())->setMethods(['createReRunUrl'])->getMock();
         $subject->expects(self::once())->method('createReRunUrl')
-            ->will(self::returnValue($reRunUrl));
+            ->willReturn($reRunUrl);
 
         self::assertContains(
             'alt=""',
@@ -713,7 +744,8 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function createReRunUrlContainsModuleParameter()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $testCase */
-        $testCase = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $testCase = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])
+            ->getMock();
 
         self::assertContains(
             '.php?M=' . \Tx_Phpunit_BackEnd_Module::MODULE_NAME,
@@ -727,7 +759,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function createReRunUrlContainsRunSingleCommand()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $test */
-        $test = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $test = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])->getMock();
 
         self::assertContains(
             'tx_phpunit%5Bcommand%5D=runsingletest',
@@ -741,7 +773,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function createReRunUrlContainsTestCaseFileName()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $test */
-        $test = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $test = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])->getMock();
 
         $this->subject->setTestSuiteName('myTestCase');
 
@@ -757,7 +789,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function createReRunUrlContainsTestCaseName()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $test */
-        $test = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $test = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])->getMock();
 
         $this->subject->setTestSuiteName('myTestCase');
 
@@ -773,7 +805,7 @@ class TestListenerTest extends \Tx_Phpunit_TestCase
     public function createReRunUrlEscapesAmpersands()
     {
         /** @var \PHPUnit_Framework_TestCase|\PHPUnit_Framework_TestSuite $test */
-        $test = $this->getMock(\PHPUnit_Framework_TestCase::class, [], ['myTest']);
+        $test = $this->getMockBuilder(\PHPUnit_Framework_TestCase::class)->setConstructorArgs(['myTest'])->getMock();
 
         $this->subject->setTestSuiteName('myTestCase');
 

--- a/Tests/Unit/FrameworkTest.php
+++ b/Tests/Unit/FrameworkTest.php
@@ -1387,11 +1387,11 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->setUploadFolderPath(PATH_site . 'typo3temp/tx_phpunit_test/');
         $this->subject->createDummyFile();
 
-        self::assertTrue(is_dir($this->subject->getUploadFolderPath()));
+        self::assertDirectoryExists($this->subject->getUploadFolderPath());
 
         $this->subject->cleanUp();
 
-        self::assertFalse(is_dir($this->subject->getUploadFolderPath()));
+        self::assertDirectoryNotExists($this->subject->getUploadFolderPath());
     }
 
     /**
@@ -1401,7 +1401,8 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
     {
         $this->subject->purgeHooks();
 
-        $cleanUpHookMock = $this->getMock(\Tx_Phpunit_Interface_FrameworkCleanupHook::class, ['cleanUp']);
+        $cleanUpHookMock = $this->getMockBuilder(\Tx_Phpunit_Interface_FrameworkCleanupHook::class)
+            ->setMethods(['cleanUp'])->getMock();
         $cleanUpHookMock->expects(self::atLeastOnce())->method('cleanUp');
 
         $hookClassName = get_class($cleanUpHookMock);
@@ -1419,7 +1420,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->purgeHooks();
 
         $hookClassName = uniqid('cleanUpHook');
-        $cleanUpHookMock = $this->getMock($hookClassName, ['cleanUp']);
+        $cleanUpHookMock = $this->getMockBuilder($hookClassName)->setMethods(['cleanUp'])->getMock();
 
         $GLOBALS['T3_VAR']['getUserObj'][$hookClassName] = $cleanUpHookMock;
         $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['phpunit']['FrameworkCleanUp']['phpunit_tests'] = $hookClassName;
@@ -3561,7 +3562,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->setUploadFolderPath(PATH_site . 'typo3temp/tx_phpunit_test/');
         $this->subject->createDummyFile();
 
-        self::assertTrue(is_dir($this->subject->getUploadFolderPath()));
+        self::assertDirectoryExists($this->subject->getUploadFolderPath());
     }
 
     /**
@@ -3739,7 +3740,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->setUploadFolderPath(PATH_site . 'typo3temp/tx_phpunit_test/');
         $this->subject->createDummyZipArchive();
 
-        self::assertTrue(is_dir($this->subject->getUploadFolderPath()));
+        self::assertDirectoryExists($this->subject->getUploadFolderPath());
     }
 
     /**
@@ -3817,7 +3818,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
     {
         $dummyFolder = $this->subject->createDummyFolder('test_folder');
 
-        self::assertTrue(is_dir($dummyFolder));
+        self::assertDirectoryExists($dummyFolder);
     }
 
     /**
@@ -3831,7 +3832,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
             '/test_folder'
         );
 
-        self::assertTrue(is_dir($innerDummyFolder));
+        self::assertDirectoryExists($innerDummyFolder);
     }
 
     /**
@@ -3842,7 +3843,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->setUploadFolderPath(PATH_site . 'typo3temp/tx_phpunit_test/');
         $this->subject->createDummyFolder('test_folder');
 
-        self::assertTrue(is_dir($this->subject->getUploadFolderPath()));
+        self::assertDirectoryExists($this->subject->getUploadFolderPath());
     }
 
     /**
@@ -3853,7 +3854,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
         $this->subject->setUploadFolderPath(PATH_site . 'typo3temp/tx_phpunit_test/');
         $dummyFolder = $this->subject->createDummyFolder('test_folder');
 
-        self::assertTrue(is_dir($dummyFolder));
+        self::assertDirectoryExists($dummyFolder);
     }
 
     // ---------------------------------------------------------------------
@@ -3870,7 +3871,7 @@ class FrameworkTest extends \Tx_Phpunit_TestCase
             $this->subject->getPathRelativeToUploadDirectory($dummyFolder)
         );
 
-        self::assertFalse(is_dir($dummyFolder));
+        self::assertDirectoryNotExists($dummyFolder);
     }
 
     /**

--- a/Tests/Unit/Selenium/TestCaseTest.php
+++ b/Tests/Unit/Selenium/TestCaseTest.php
@@ -32,17 +32,13 @@ class TestCaseTest extends \Tx_Phpunit_TestCase
         }
 
         $this->extensionSettingsService = new \Tx_Phpunit_TestingDataContainer();
-        $this->seleniumService = $this->getMock(
-            \Tx_Phpunit_Service_SeleniumService::class,
-            null,
-            [$this->extensionSettingsService]
-        );
-        $this->subject = $this->getMock(
-            $this->createAccessibleProxyClass(),
-            ['isSeleniumServerRunning'],
-            [null, [], '', $this->extensionSettingsService, $this->seleniumService]
-        );
-        $this->subject->expects(self::any())->method('isSeleniumServerRunning')->will(self::returnValue(true));
+        $this->seleniumService = $this->getMockBuilder(\Tx_Phpunit_Service_SeleniumService::class)
+            ->setMethods(null)->setConstructorArgs([$this->extensionSettingsService])->getMock();
+        $this->subject = $this->getMockBuilder($this->createAccessibleProxyClass())
+            ->setMethods(['isSeleniumServerRunning'])
+            ->setConstructorArgs([null, [], '', $this->extensionSettingsService, $this->seleniumService])
+            ->getMock();
+        $this->subject->method('isSeleniumServerRunning')->willReturn(true);
     }
 
     /*

--- a/Tests/Unit/Service/SeleniumServiceTest.php
+++ b/Tests/Unit/Service/SeleniumServiceTest.php
@@ -22,11 +22,8 @@ class SeleniumServiceTest extends \Tx_Phpunit_TestCase
     protected function setUp()
     {
         $this->extensionSettingsService = new \Tx_Phpunit_TestingDataContainer();
-        $this->subject = $this->getMock(
-            \Tx_Phpunit_Service_SeleniumService::class,
-            null,
-            [$this->extensionSettingsService]
-        );
+        $this->subject = $this->getMockBuilder(\Tx_Phpunit_Service_SeleniumService::class)
+            ->setMethods(null)->setConstructorArgs([$this->extensionSettingsService])->getMock();
     }
 
     /**

--- a/Tests/Unit/Service/TestCaseServiceTest.php
+++ b/Tests/Unit/Service/TestCaseServiceTest.php
@@ -99,13 +99,11 @@ class TestCaseServiceTest extends \Tx_Phpunit_TestCase
         $path = 'OneTest.php';
 
         /** @var \Tx_Phpunit_Service_TestCaseService|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            \Tx_Phpunit_Service_TestCaseService::class,
-            ['isNotFixturesPath', 'isTestCaseFileName']
-        );
-        $subject->expects(self::any())->method('isNotFixturesPath')->will(self::returnValue(true));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestCaseService::class)
+            ->setMethods(['isNotFixturesPath', 'isTestCaseFileName'])->getMock();
+        $subject->method('isNotFixturesPath')->willReturn(true);
         $subject->expects(self::at(1))->method('isTestCaseFileName')
-            ->with($this->fixturesPath . $path)->will(self::returnValue(true));
+            ->with($this->fixturesPath . $path)->willReturn(true);
 
         self::assertContains(
             $path,
@@ -121,13 +119,11 @@ class TestCaseServiceTest extends \Tx_Phpunit_TestCase
         $path = 'OneTest.php';
 
         /** @var \Tx_Phpunit_Service_TestCaseService|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(
-            \Tx_Phpunit_Service_TestCaseService::class,
-            ['isNotFixturesPath', 'isTestCaseFileName']
-        );
-        $subject->expects(self::any())->method('isNotFixturesPath')->will(self::returnValue(true));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestCaseService::class)
+            ->setMethods(['isNotFixturesPath', 'isTestCaseFileName'])->getMock();
+        $subject->method('isNotFixturesPath')->willReturn(true);
         $subject->expects(self::at(1))->method('isTestCaseFileName')
-            ->with($this->fixturesPath . $path)->will(self::returnValue(false));
+            ->with($this->fixturesPath . $path)->willReturn(false);
 
         self::assertNotContains(
             $path,

--- a/Tests/Unit/Service/TestFinderTest.php
+++ b/Tests/Unit/Service/TestFinderTest.php
@@ -110,9 +110,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestableForKeyForEmptyKeyThrowsException()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         $this->expectException(\InvalidArgumentException::class);
 
@@ -127,10 +128,11 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $testable = new \Tx_Phpunit_Testable();
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject
             ->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => $testable]));
+            ->willReturn(['foo' => $testable]);
 
         self::assertSame(
             $testable,
@@ -144,9 +146,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestableForKeyForInexistentKeyThrowsException()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         $this->expectException(\BadMethodCallException::class);
 
@@ -159,9 +162,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForKeyForEmptyKeyReturnsFalse()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         self::assertFalse(
             $subject->existsTestableForKey('')
@@ -174,9 +178,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForKeyForExistingKeyReturnsTrue()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         self::assertTrue(
             $subject->existsTestableForKey('foo')
@@ -189,9 +194,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForKeyForInexistentKeyReturnsFalse()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $subject */
-        $subject = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $subject->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $subject = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $subject->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         self::assertFalse(
             $subject->existsTestableForKey('bar')
@@ -208,11 +214,9 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForEverythingNoExtensionTestsReturnsEmptyArray()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getTestablesForExtensions']
-        );
-        $testFinder->expects(self::once())->method('getTestablesForExtensions')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForExtensions'])->getMock();
+        $testFinder->expects(self::once())->method('getTestablesForExtensions')->willReturn([]);
 
         self::assertSame(
             [],
@@ -228,12 +232,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $extensionTests = new \Tx_Phpunit_Testable();
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getTestablesForExtensions']
-        );
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForExtensions'])->getMock();
         $testFinder->expects(self::once())->method('getTestablesForExtensions')
-            ->will(self::returnValue(['foo' => $extensionTests]));
+            ->willReturn(['foo' => $extensionTests]);
 
         self::assertSame(
             ['foo' => $extensionTests],
@@ -249,12 +251,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $extensionTests = new \Tx_Phpunit_Testable();
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getTestablesForExtensions']
-        );
-        $testFinder->expects(self::any())->method('getTestablesForExtensions')
-            ->will(self::returnValue(['foo' => $extensionTests]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForExtensions'])->getMock();
+        $testFinder->method('getTestablesForExtensions')
+            ->willReturn(['foo' => $extensionTests]);
 
         self::assertSame(
             $testFinder->getTestablesForEverything(),
@@ -272,9 +272,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForAnythingForNoTestablesReturnsFalse()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([]);
 
         self::assertFalse(
             $testFinder->existsTestableForAnything()
@@ -287,9 +288,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForAnythingForOneTestableReturnsTrue()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable()]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable()]);
 
         self::assertTrue(
             $testFinder->existsTestableForAnything()
@@ -302,9 +304,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function existsTestableForAnythingForTwoTestablessReturnsTrue()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue(['foo' => new \Tx_Phpunit_Testable(), 'bar' => new \Tx_Phpunit_Testable()]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn(['foo' => new \Tx_Phpunit_Testable(), 'bar' => new \Tx_Phpunit_Testable()]);
 
         self::assertTrue(
             $testFinder->existsTestableForAnything()
@@ -404,29 +407,29 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsCreatesTestableForSingleExtensionForInstalledExtensionsWithoutExcludedExtensions(
     ) {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([
             'foo',
             'bar',
             'foobar',
-        ]));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([
+        ]);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([
             'foo',
             'baz',
-        ]));
+        ]);
 
         $testFinder->expects(self::at(2))->method('createTestableForSingleExtension')
-            ->with('bar')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('bar')->willReturn(new \Tx_Phpunit_Testable());
         $testFinder->expects(self::at(3))->method('createTestableForSingleExtension')
-            ->with('foobar')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('foobar')->willReturn(new \Tx_Phpunit_Testable());
 
         $testFinder->getTestablesForExtensions();
     }
@@ -437,31 +440,31 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsCreatesTestableForSingleExtensionForInstalledExtensionsWithoutDummyExtensions(
     ) {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'getDummyExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'getDummyExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([
             'foo',
             'bar',
             'foobar',
-        ]));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
-        $testFinder->expects(self::once())->method('getDummyExtensionKeys')->will(self::returnValue([
+        ]);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
+        $testFinder->expects(self::once())->method('getDummyExtensionKeys')->willReturn([
             'foo',
             'baz',
-        ]));
+        ]);
 
         $testFinder->expects(self::at(3))->method('createTestableForSingleExtension')
-            ->with('bar')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('bar')->willReturn(new \Tx_Phpunit_Testable());
         $testFinder->expects(self::at(4))->method('createTestableForSingleExtension')
-            ->with('foobar')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('foobar')->willReturn(new \Tx_Phpunit_Testable());
 
         $testFinder->getTestablesForExtensions();
     }
@@ -477,25 +480,25 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $testableForBar->setKey('bar');
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([
             'foo',
             'bar',
-        ]));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        ]);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
 
         $testFinder->expects(self::at(2))->method('createTestableForSingleExtension')
-            ->with('foo')->will(self::returnValue($testableForFoo));
+            ->with('foo')->willReturn($testableForFoo);
         $testFinder->expects(self::at(3))->method('createTestableForSingleExtension')
-            ->with('bar')->will(self::returnValue($testableForBar));
+            ->with('bar')->willReturn($testableForBar);
 
         self::assertSame(
             ['bar' => $testableForBar, 'foo' => $testableForFoo],
@@ -569,9 +572,10 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsForNoInstalledExtensionsReturnsEmptyArray()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getLoadedExtensionKeys']);
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys'])->getMock();
         $testFinder->injectExtensionSettingsService($this->extensionSettingsService);
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([]));
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([]);
 
         self::assertSame(
             [],
@@ -587,19 +591,19 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $testableInstance = new \Tx_Phpunit_Testable();
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['foo']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['foo']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('createTestableForSingleExtension')
-            ->with('foo')->will(self::returnValue($testableInstance));
+            ->with('foo')->willReturn($testableInstance);
 
         self::assertSame(
             ['foo' => $testableInstance],
@@ -613,24 +617,24 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsForTwoInstalledExtensionsWithTestsReturnsTwoResults()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([
             'foo',
             'bar',
-        ]));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        ]);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::at(2))->method('createTestableForSingleExtension')
-            ->with('foo')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('foo')->willReturn(new \Tx_Phpunit_Testable());
         $testFinder->expects(self::at(3))->method('createTestableForSingleExtension')
-            ->with('bar')->will(self::returnValue(new \Tx_Phpunit_Testable()));
+            ->with('bar')->willReturn(new \Tx_Phpunit_Testable());
 
         self::assertCount(
             2,
@@ -644,12 +648,11 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsForOneInstalledExtensionsWithoutTestsReturnsEmptyArray()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['foo']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['foo']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
             ->with('foo')->will(self::throwException(new \Tx_Phpunit_Exception_NoTestsDirectory()));
 
@@ -667,24 +670,24 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         $testableInstance = new \Tx_Phpunit_Testable();
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            [
-                'getLoadedExtensionKeys',
-                'getExcludedExtensionKeys',
-                'findTestsPathForExtension',
-                'createTestableForSingleExtension',
-            ]
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue([
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(
+                [
+                    'getLoadedExtensionKeys',
+                    'getExcludedExtensionKeys',
+                    'findTestsPathForExtension',
+                    'createTestableForSingleExtension',
+                ]
+            )->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn([
             'foo',
             'bar',
-        ]));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        ]);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::at(2))->method('createTestableForSingleExtension')
             ->with('foo')->will(self::throwException(new \Tx_Phpunit_Exception_NoTestsDirectory()));
         $testFinder->expects(self::at(3))->method('createTestableForSingleExtension')
-            ->with('bar')->will(self::returnValue($testableInstance));
+            ->with('bar')->willReturn($testableInstance);
 
         self::assertSame(
             ['bar' => $testableInstance],
@@ -698,14 +701,13 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsProvidesTestableInstanceWithExtensionKey()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['phpunit']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['phpunit']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('phpunit')->will(self::returnValue(ExtensionManagementUtility::extPath('phpunit') . 'Tests/'));
+            ->with('phpunit')->willReturn(ExtensionManagementUtility::extPath('phpunit') . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */
@@ -722,14 +724,13 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsProvidesTestableInstanceWithExtensionKeyAsTitleTitle()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['phpunit']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['phpunit']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('phpunit')->will(self::returnValue(ExtensionManagementUtility::extPath('phpunit') . 'Tests/'));
+            ->with('phpunit')->willReturn(ExtensionManagementUtility::extPath('phpunit') . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */
@@ -746,14 +747,13 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsProvidesTestableInstanceWithCodePath()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['phpunit']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['phpunit']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('phpunit')->will(self::returnValue(ExtensionManagementUtility::extPath('phpunit') . 'Tests/'));
+            ->with('phpunit')->willReturn(ExtensionManagementUtility::extPath('phpunit') . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */
@@ -770,14 +770,13 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsProvidesTestableInstanceWithTestsPath()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['phpunit']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['phpunit']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('phpunit')->will(self::returnValue(ExtensionManagementUtility::extPath('phpunit') . 'Tests/'));
+            ->with('phpunit')->willReturn(ExtensionManagementUtility::extPath('phpunit') . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */
@@ -801,17 +800,16 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
         }
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
         $testFinder->expects(self::once())
             ->method('getLoadedExtensionKeys')
-            ->will(self::returnValue(['user_phpunittest']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+            ->willReturn(['user_phpunittest']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('user_phpunittest')->will(self::returnValue(ExtensionManagementUtility::extPath('user_phpunittest')
-                . 'Tests/'));
+            ->with('user_phpunittest')->willReturn(ExtensionManagementUtility::extPath('user_phpunittest')
+                . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */
@@ -828,14 +826,13 @@ class TestFinderTest extends \Tx_Phpunit_TestCase
     public function getTestablesForExtensionsWithPngIconProvidesTestableInstanceWithIconPath()
     {
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(
-            \Tx_Phpunit_Service_TestFinder::class,
-            ['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension']
-        );
-        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->will(self::returnValue(['phpunit']));
-        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getLoadedExtensionKeys', 'getExcludedExtensionKeys', 'findTestsPathForExtension'])
+            ->getMock();
+        $testFinder->expects(self::once())->method('getLoadedExtensionKeys')->willReturn(['phpunit']);
+        $testFinder->expects(self::once())->method('getExcludedExtensionKeys')->willReturn([]);
         $testFinder->expects(self::once())->method('findTestsPathForExtension')
-            ->with('phpunit')->will(self::returnValue(ExtensionManagementUtility::extPath('phpunit') . 'Tests/'));
+            ->with('phpunit')->willReturn(ExtensionManagementUtility::extPath('phpunit') . 'Tests/');
 
         $testables = $testFinder->getTestablesForExtensions();
         /** @var \Tx_Phpunit_Testable $testable */

--- a/Tests/Unit/Service/UserSettingsServiceTest.php
+++ b/Tests/Unit/Service/UserSettingsServiceTest.php
@@ -33,7 +33,7 @@ class UserSettingsServiceTest extends \Tx_Phpunit_TestCase
             self::markTestSkipped('The BE module is not available in TYPO3 CMS >= 8.');
         }
 
-        $GLOBALS['BE_USER'] = $this->getMock(BackendUserAuthentication::class);
+        $GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
 
         $this->subject = new \Tx_Phpunit_Service_UserSettingsService();
     }

--- a/Tests/Unit/TestCaseTest.php
+++ b/Tests/Unit/TestCaseTest.php
@@ -40,7 +40,7 @@ class TestCaseTest extends \Tx_Phpunit_TestCase
         require_once __DIR__ . '/Fixtures/ProtectedClass.php';
 
         $this->protectedClassInstance = new ProtectedClass();
-        $this->mock = $this->getMock(ProtectedClass::class, ['dummy']);
+        $this->mock = $this->getMockBuilder(ProtectedClass::class)->setMethods(['dummy'])->getMock();
         $this->accessibleMock = $this->getAccessibleMock(
             ProtectedClass::class,
             ['dummy']

--- a/Tests/Unit/ViewHelpers/ExtensionSelectorViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/ExtensionSelectorViewHelperTest.php
@@ -55,8 +55,8 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         }
 
         /** @var LanguageService|\PHPUnit_Framework_MockObject_MockObject $languageServiceMock */
-        $languageServiceMock = $this->getMock(LanguageService::class);
-        $languageServiceMock->expects(static::any())->method('getLL')->willReturn('translatedLabel');
+        $languageServiceMock = $this->createMock(LanguageService::class);
+        $languageServiceMock->method('getLL')->willReturn('translatedLabel');
         $GLOBALS['LANG'] = $languageServiceMock;
 
         $this->subject = new \Tx_Phpunit_ViewHelpers_ExtensionSelectorViewHelper();
@@ -172,8 +172,9 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')->will(self::returnValue([]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')->willReturn([]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();
@@ -199,9 +200,10 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([$extensionKey => $testable]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([$extensionKey => $testable]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();
@@ -227,9 +229,10 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([$extensionKey => $testable]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([$extensionKey => $testable]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();
@@ -262,9 +265,10 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([$extensionKey1 => $testable1, $extensionKey2 => $testable2]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([$extensionKey1 => $testable1, $extensionKey2 => $testable2]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();
@@ -290,9 +294,10 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([$extensionKey => $testable]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([$extensionKey => $testable]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();
@@ -318,9 +323,10 @@ class ExtensionSelectorViewHelperTest extends \Tx_Phpunit_TestCase
         $subject->injectUserSettingService($this->userSettingsService);
 
         /** @var \Tx_Phpunit_Service_TestFinder|\PHPUnit_Framework_MockObject_MockObject $testFinder */
-        $testFinder = $this->getMock(\Tx_Phpunit_Service_TestFinder::class, ['getTestablesForEverything']);
-        $testFinder->expects(self::any())->method('getTestablesForEverything')
-            ->will(self::returnValue([$extensionKey => $testable]));
+        $testFinder = $this->getMockBuilder(\Tx_Phpunit_Service_TestFinder::class)
+            ->setMethods(['getTestablesForEverything'])->getMock();
+        $testFinder->method('getTestablesForEverything')
+            ->willReturn([$extensionKey => $testable]);
         $subject->injectTestFinder($testFinder);
 
         $subject->render();


### PR DESCRIPTION
This ensures that running the tests with PHPUnit 5.7 does not create
deprecation notices.

Also use more explicity assertions where they are available.