### PR TITLE
[CLEANUP] Drop the destructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Deprecate Tx_Phpunit_Service_Database (#76)
 
 ### Removed
+- Drop the destructors (#99)
 - Drop the ancient unused TestSuite class (#97)
 - Drop the direct phpunit/phpunit dependency (#90)
 - Remove the unused PHPUnit configuration file (#76)

--- a/Classes/BackEnd/Ajax.php
+++ b/Classes/BackEnd/Ajax.php
@@ -51,14 +51,6 @@ class Tx_Phpunit_BackEnd_Ajax
     }
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->userSettingsService);
-    }
-
-    /**
      * Injects the user settings service.
      *
      * @param \Tx_Phpunit_Interface_UserSettingsService $service the service to inject

--- a/Classes/BackEnd/Module.php
+++ b/Classes/BackEnd/Module.php
@@ -92,23 +92,6 @@ class Tx_Phpunit_BackEnd_Module extends BaseScriptClass
     }
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset(
-            $this->request,
-            $this->testFinder,
-            $this->coverage,
-            $this->testListener,
-            $this->outputService,
-            $this->userSettingsService,
-            $this->testStatistics,
-            $this->testCaseService
-        );
-    }
-
-    /**
      * Injects the request.
      *
      * @param \Tx_Phpunit_Interface_Request $request the request to inject

--- a/Classes/BackEnd/TestListener.php
+++ b/Classes/BackEnd/TestListener.php
@@ -108,14 +108,6 @@ class Tx_Phpunit_BackEnd_TestListener implements \PHPUnit_Framework_TestListener
     protected $namePrettifier = null;
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->namePrettifier, $this->outputService);
-    }
-
-    /**
      * Injects the name prettifier.
      *
      * @param \PHPUnit_Util_TestDox_NamePrettifier $namePrettifier the name prettifier to inject

--- a/Classes/Service/TestCaseService.php
+++ b/Classes/Service/TestCaseService.php
@@ -62,14 +62,6 @@ class Tx_Phpunit_Service_TestCaseService implements SingletonInterface
     }
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->userSettingsService);
-    }
-
-    /**
      * Finds all files that are named like test files in the directory $directory
      * and recursively all its subdirectories.
      *

--- a/Classes/Service/TestFinder.php
+++ b/Classes/Service/TestFinder.php
@@ -60,14 +60,6 @@ class Tx_Phpunit_Service_TestFinder implements SingletonInterface
     }
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->extensionSettingsService);
-    }
-
-    /**
      * Checks whether there is testable code for a key.
      *
      * @param string $key

--- a/Classes/ViewHelpers/AbstractSelectorViewHelper.php
+++ b/Classes/ViewHelpers/AbstractSelectorViewHelper.php
@@ -25,15 +25,6 @@ abstract class Tx_Phpunit_ViewHelpers_AbstractSelectorViewHelper extends \Tx_Php
     protected $action = '';
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->userSettingService, $this->testFinder);
-        parent::__destruct();
-    }
-
-    /**
      * Injects the user setting service.
      *
      * @param \Tx_Phpunit_Interface_UserSettingsService $userSettingService

--- a/Classes/ViewHelpers/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/AbstractViewHelper.php
@@ -17,14 +17,6 @@ abstract class Tx_Phpunit_ViewHelpers_AbstractViewHelper
     protected $outputService = null;
 
     /**
-     * The destructor.
-     */
-    public function __destruct()
-    {
-        unset($this->outputService);
-    }
-
-    /**
      * Injects the output service.
      *
      * @param \Tx_Phpunit_Service_OutputService $service the service to inject


### PR DESCRIPTION
The constructors were merely unsetting fields. Nowadays, the PHP garbage
collector does not need this anymore.