### PR TITLE
[TASK] Move Tests/ from autoload-dev to autoload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 ### Changed
+- Move Tests/ from autoload-dev to autoload (#133)
 - Completely switch to PSR-4 autoloading (#125)
 - Simplify the test run command configuration in .travis.yml (#123)
 - Require PHP >= 7.0 (#121)

--- a/Tests/Unit/TestCaseTest.php
+++ b/Tests/Unit/TestCaseTest.php
@@ -39,8 +39,6 @@ class TestCaseTest extends TestCase
 
     protected function setUp()
     {
-        require_once __DIR__ . '/Fixtures/ProtectedClass.php';
-
         $this->protectedClassInstance = new ProtectedClass();
         $this->mock = $this->getMockBuilder(ProtectedClass::class)->setMethods(['dummy'])->getMock();
         $this->accessibleMock = $this->getAccessibleMock(

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,7 @@
     },
     "autoload": {
         "psr-4": {
-            "OliverKlee\\PhpUnit\\": "Classes/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "OliverKlee\\PhpUnit\\": "Classes/",
             "OliverKlee\\PhpUnit\\Tests\\": "Tests/"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,13 +14,13 @@ $EM_CONF[$_EXTKEY] = [
         'suggests' => [],
     ],
     'state' => 'stable',
-    'clearCacheOnLoad' => false,
     'author' => 'Oliver Klee',
     'author_email' => 'typo3-coding@oliverklee.de',
     'author_company' => 'oliverklee.de',
     'autoload' => [
         'psr-4' => [
-            'OliverKlee\\PhpUnit\\' => 'Classes/'
+            'OliverKlee\\PhpUnit\\' => 'Classes/',
+            'OliverKlee\\PhpUnit\\Tests\\' => 'Tests/'
         ],
     ],
 ];


### PR DESCRIPTION
This allows running the tests from within an existing installation.

As this extension should only be used as a dev dependency, this should
not have any impact on production systems.

Also drop the `require_once` of a fixture class.