### PR TITLE
[TASK] Stop building with the lowest Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 install:
 - >
-  composer require typo3/minimal:"$TYPO3" $DEPENDENCIES_PREFERENCE;
+  composer require typo3/minimal:"$TYPO3";
   composer show;
 - >
   .Build/vendor/bin/typo3cms install:setup --non-interactive --site-setup-type="site"
@@ -52,32 +52,17 @@ jobs:
     php: "7.3"
     env: TYPO3=^9.5
   - stage: test
-    php: "7.3"
-    env: TYPO3=^9.5 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
     php: "7.2"
     env: TYPO3=^9.5
   - stage: test
-    php: "7.2"
-    env: TYPO3=^9.5 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
     php: "7.3"
     env: TYPO3=^8.7
   - stage: test
-    php: "7.3"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
     php: "7.2"
     env: TYPO3=^8.7
   - stage: test
-    php: "7.2"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
     php: "7.1"
     env: TYPO3=^8.7
-  - stage: test
-    php: "7.1"
-    env: TYPO3=^8.7 DEPENDENCIES_PREFERENCE="--prefer-lowest"
   - stage: release to ter
     if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
     php: "7.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ included PHPUnit package.
 ### Deprecated
 
 ### Removed
+- Stop building with the lowest Composer dependencies (#144)
 - Drop the TYPO3 package repository from composer.json (#139)
 
 ### Fixed


### PR DESCRIPTION
This has been too much of a hassle due to breakage caused by old
dev dependencies.