### PR TITLE
[TASK] Improve the code autoformatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ included PHPUnit package.
 - Add code sniffing to the Travis CI build (#143)
 
 ### Changed
+- Improve the code autoformatting (#158)
 - Sort the entries in the `.gitignore` and `.gitattributes` (#157)
 - Use PHP 7.2 for the TER release script (#155)
 - Sort the Composer dependencies (#153)

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
             "@ci:static",
             "@ci:dynamic"
         ],
-        "fix:php-cs": "php-cs-fixer fix",
+        "php:fix": "php-cs-fixer fix && phpcbf Classes Configuration Tests",
         "link-extension": [
             "@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
             "@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/phpunit\") || symlink(__DIR__,$extFolder);'"


### PR DESCRIPTION
Now the `php:fix` Composer script runs `phpcbf` in addition to
`php-cs-fixer`.

Also rename the script to match my other extensions.