### PR TITLE
[BUGFIX] Allow TYPO3 up to version 10.4.x in ext_emconf.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ included PHPUnit package.
 
 ### Fixed
 
+## 7.5.21
+
+### Fixed
+- Allow TYPO3 up to version 10.4.x in `ext_emconf.php` (#170)
+
 ## 7.5.20
 
 ### Added

--- a/Documentation/Settings.yml
+++ b/Documentation/Settings.yml
@@ -7,7 +7,7 @@ conf.py:
   copyright: 2020
   project: PHPUnit
   version: 7.5
-  release: 7.5.20
+  release: 7.5.21
   latex_documents:
   - - Index
     - phpunit.tex

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,12 +3,12 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'PHPUnit',
     'description' => 'Unit testing for TYPO3. Includes PHPUnit and a CLI test runner.',
-    'version' => '7.5.20',
+    'version' => '7.5.21',
     'category' => 'misc',
     'constraints' => [
         'depends' => [
             'php' => '7.1.0-7.4.99',
-            'typo3' => '8.7.0-10.0.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This makes the extension actually installable in TYPO3 10.3 and 10.4.