### PR TITLE
[BUGFIX] Do not cache vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 cache:
   directories:
-  - .Build/vendor
   - $HOME/.composer/cache
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ included PHPUnit package.
 ### Removed
 
 ### Fixed
+- Do not cache `vendor/` on Travis CI (#171)
 
 ## 7.5.21
 


### PR DESCRIPTION
This causes too much trouble with version conflicts.

Caching the Composer cache should be enough anyway.