### PR TITLE
[BUGFIX] Always use Composer-installed versions of the dev tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ included PHPUnit package.
 - Drop support for TYPO3 8.7 (#174)
 
 ### Fixed
+- Always use Composer-installed versions of the dev tools (#181)
 - Add `var/` to the `.gitignore` (#180)
 - Fix some incomplete PHPDoc (#176)
 - Fix warnings in the `travis.yml` (#172)

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,8 @@
     },
     "scripts": {
         "ci:php:lint": "find *.php Classes Configuration Migrations Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",
-        "ci:php:sniff": "phpcs Classes Configuration Tests",
-        "ci:php:fixer": "php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff",
+        "ci:php:sniff": ".Build/vendor/bin/phpcs Classes Configuration Tests",
+        "ci:php:fixer": ".Build/vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff",
         "ci:tests:unit": ".Build/vendor/bin/typo3 phpunit:run --options=\"Tests/Unit\"",
         "ci:tests": [
             "@ci:tests:unit"
@@ -75,7 +75,7 @@
             "@ci:static",
             "@ci:dynamic"
         ],
-        "php:fix": "php-cs-fixer fix && phpcbf Classes Configuration Tests",
+        "php:fix": ".Build/vendor/bin/php-cs-fixer fix && .Build/vendor/bin/phpcbf Classes Configuration Tests",
         "link-extension": [
             "@php -r 'is_dir($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/\") || mkdir($extFolder, 0777, true);'",
             "@php -r 'file_exists($extFolder=__DIR__.\"/.Build/public/typo3conf/ext/phpunit\") || symlink(__DIR__,$extFolder);'"


### PR DESCRIPTION
This avoids system-installed versions of the same tools
from getting called instead (which might be a different version and
also might not use our Composer autoloader).