### PR TITLE
[BUGFIX] Add .0 version suffixes to PHP version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ included PHPUnit package.
 - Drop support for TYPO3 8.7 (#174)
 
 ### Fixed
+- Add `.0` version suffixes to PHP version requirements (#183)
 - Always use Composer-installed versions of the dev tools (#181)
 - Add `var/` to the `.gitignore` (#180)
 - Fix some incomplete PHPDoc (#176)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/oliverklee/ext-phpunit"
     },
     "require": {
-        "php": "~7.2 || ~7.3 || ~7.4",
+        "php": "~7.2.0 || ~7.3.0 || ~7.4.0",
         "symfony/console": "^4.0 || ^5.0",
         "typo3/cms-core": "^9.5 || ^10.3"
     },


### PR DESCRIPTION
Allowing PHP `~7.4` would allow PHP 7.5 as well (even if that version
most probably will not exist), while `~7.4.0` will not due to the way
the `~` operator for Composer version requirements works.