### PR TITLE
[TASK] Deprecate `getAccessibleMock`, `buildAccessibleProxy`, `AccessibleObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ included PHPUnit package.
 - Limit the allowed number of arguments to `_call` to 9 (#230)
 
 ### Deprecated
+- Deprecate `getAccessibleMock`, `buildAccessibleProxy` and `AccessibleObject` (#241)
 
 ### Removed
 - Drop `_callRef`, `_setRef`, `getStatic`, `setStatic` and `getProtectedProperty` (#237)

--- a/Classes/Interfaces/AccessibleObject.php
+++ b/Classes/Interfaces/AccessibleObject.php
@@ -7,6 +7,8 @@ namespace OliverKlee\PhpUnit\Interfaces;
 /**
  * This interface defines the methods provided by TestCase::getAccessibleMock.
  *
+ * @deprecated will be removed in PHPUnit 8
+ *
  * @author Nicole Cordes <nicole.cordes@googlemail.com>
  */
 interface AccessibleObject

--- a/Classes/TestCase.php
+++ b/Classes/TestCase.php
@@ -42,6 +42,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      *         a mock of `$originalClassName` with access methods added
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated will be removed in PHPUnit 8
      */
     protected function getAccessibleMock(
         string $originalClassName,
@@ -77,6 +79,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param string $className name of class to make available, must not be empty
      *
      * @return string fully-qualified name of the built class, will not be empty
+     *
+     * @deprecated will be removed in PHPUnit 8
      */
     protected function buildAccessibleProxy(string $className): string
     {


### PR DESCRIPTION
Fixes #227
Fixes #232