### PR TITLE
[BUGFIX] Use `$_EXTKEY` in `ext_emconf.php` again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ included PHPUnit package.
 - Drop obsolete screenshots from the manual (#261)
 
 ### Fixed
+- Use `$_EXTKEY` in `ext_emconf.php` again (#263)
 - Fix a Composer script description key (#258)
 
 ## 7.5.23

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF['phpunit'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'PHPUnit',
     'description' => 'Unit testing for TYPO3. Includes PHPUnit and a CLI test runner.',
     'version' => '7.5.23',


### PR DESCRIPTION
According to the docs, the TER needs this.

This reverts commit b9768b213a6a67f10ad21f1becf934ed1cc5a3af.