### PR TITLE
[TASK] Use generics for accessible mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ included PHPUnit package.
 ## x.y.z
 
 ### Added
+- Use generics for accessible mocks (#265)
 
 ### Changed
 

--- a/Classes/TestCase.php
+++ b/Classes/TestCase.php
@@ -31,14 +31,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Creates a mock object which allows for calling protected methods and access of protected properties.
      *
-     * @param class-string $originalClassName name of class to create the mock object of, must not be empty
+     * @template M of object
+     *
+     * @param class-string<M> $originalClassName name of class to create the mock object of, must not be empty
      * @param string[]|null $methods names of the methods to mock, null for "mock no methods"
      * @param array<int, mixed> $arguments arguments to pass to constructor
      * @param string $mockClassName the class name to use for the mock class
      * @param bool $callOriginalConstructor whether to call the constructor
      * @param bool $callOriginalClone whether to call the __clone method
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject&AccessibleObject
+     * @return \PHPUnit_Framework_MockObject_MockObject&AccessibleObject&M
      *         a mock of `$originalClassName` with access methods added
      *
      * @throws \InvalidArgumentException
@@ -53,7 +55,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         bool $callOriginalConstructor = true,
         bool $callOriginalClone = true
     ) {
-        // @phpstan-ignore-next-line We're testing a contract violation here on purpose.
         if ($originalClassName === '') {
             throw new \InvalidArgumentException('$originalClassName must not be empty.', 1334701880);
         }
@@ -67,7 +68,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
             $mockBuilder->disableOriginalClone();
         }
 
-        /** @var \PHPUnit_Framework_MockObject_MockObject&AccessibleObject $mock */
+        /** @var \PHPUnit_Framework_MockObject_MockObject&AccessibleObject&M $mock */
         $mock = $mockBuilder->getMock();
 
         return $mock;
@@ -77,15 +78,17 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * Creates a proxy class of the specified class which allows for calling even protected methods and access of
      * protected properties.
      *
-     * @param class-string $className name of class to make available, must not be empty
+     * @template M of object
      *
-     * @return class-string fully-qualified name of the built class, will not be empty
+     * @param class-string<M> $className name of class to make available, must not be empty
+     *
+     * @return class-string<M&AccessibleObject> fully-qualified name of the built class, will not be empty
      *
      * @deprecated will be removed in PHPUnit 8
      */
     protected function buildAccessibleProxy(string $className): string
     {
-        /** @var class-string $accessibleClassName */
+        /** @var class-string<M&AccessibleObject> $accessibleClassName */
         $accessibleClassName = \str_replace('.', '', \uniqid('Tx_Phpunit_AccessibleProxy', true));
         $class = new \ReflectionClass($className);
         $abstractModifier = $class->isAbstract() ? 'abstract ' : '';


### PR DESCRIPTION
This helps static analysis for classes that use the corresponding
methods.

Fixes #264