### PR TITLE
[TASK] Deprecate the test base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ PHPUnit package this extension is intended to be used in conjunction with.
 - Upgrade to PHPUnit 8.5 (#263)
 
 ### Deprecated
+- Deprecate the test base class (#288)
 
 ### Removed
 - Drop `AccessibleObject`, `getAccessibleMock` and `buildAccessibleProxy` (#287)

--- a/Classes/TestCase.php
+++ b/Classes/TestCase.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace OliverKlee\PhpUnit;
 
 /**
- * This base class provides helper functions that might be convenient when testing in TYPO3.
+ * Base class for test cases.
+ *
+ * @deprecated will be removed in phpunit 9.x; directly use `\PHPUnit\Framework\TestCase` instead
  *
  * @author Robert Lemke <robert@typo3.org>
  * @author Kasper Ligaard <kasperligaard@gmail.com>


### PR DESCRIPTION
Now that the deprecated code is removed, the base class is practically
empty, and there is no reason to keep it.