### PR TITLE
[TASK] Explicitly allow the needed Composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,12 @@
 			"*": "dist"
 		},
 		"sort-packages": true,
-		"vendor-dir": ".Build/vendor"
+		"vendor-dir": ".Build/vendor",
+		"allow-plugins": {
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true,
+			"phpstan/extension-installer": true
+		}
 	},
 	"scripts": {
 		"ci:php:lint": "find *.php Classes Configuration Tests -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l",


### PR DESCRIPTION
This is required for Composer 2.2.