### PR TITLE
[BUGFIX] Exclude the TYPO3 console from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,6 @@ updates:
         interval: "daily"
       allow:
         - dependency-type: "development"
+        ignore:
+          -   dependency-name: "helhum/typo3-console"
       versioning-strategy: "increase"


### PR DESCRIPTION
This package is required in multiple major versions, which does not
go well with Dependabot.