### PR TITLE
[BUGFIX] Allow `helhum/typo3-console-plugin` as Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,9 +61,10 @@
 		"sort-packages": true,
 		"vendor-dir": ".Build/vendor",
 		"allow-plugins": {
+			"helhum/typo3-console-plugin": true,
+			"phpstan/extension-installer": true,
 			"typo3/class-alias-loader": true,
-			"typo3/cms-composer-installers": true,
-			"phpstan/extension-installer": true
+			"typo3/cms-composer-installers": true
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
Also sort the list of allowed Composer plugins.