### PR TITLE
[TASK] Require `typo3/cms-core` instead of `typo3/minimal` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           TYPO3: "${{ matrix.typo3-version }}"
         name: "Install TYPO3 Core"
         run: |
-          composer require --no-progress typo3/minimal:"$TYPO3"
+          composer require --no-progress typo3/cms-core:"$TYPO3"
           composer show
       - name: "Set up TYPO3"
         run: >


### PR DESCRIPTION
This unblocks using the development version of TYPO3.

Fixes #346