### PR TITLE
[BUGFIX] Block Dependabot updates for phpstan-typo3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,7 @@ updates:
         versions: [ ">= 3.4.0" ]
       - dependency-name: "phpunit/phpunit"
         versions: [ ">= 9" ]
+      - dependency-name: "saschaegerer/phpstan-typo3"
+        versions: [ ">= 1.8.0" ]
       - dependency-name: "symfony/console"
     versioning-strategy: "increase"


### PR DESCRIPTION
These upgrades would break 9LTS compatibility.