### PR TITLE
[TASK] Bump the Symfony dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ PHPUnit package this extension is intended to be used with.
 - Add support for PHP 8.2 (#349)
 
 ### Changed
+- Bump the Symfony dependencies (#380)
 - Switch to the TYPO3 Code of Conduct (#309)
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": ">= 7.2",
-		"symfony/console": "^4.4 || ^5.1 || ^6.0",
+		"symfony/console": "^4.4 || ^5.4 || ^6.1",
 		"typo3/cms-core": "^9.5 || ^10.4 || ^11.5.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Only support versions that have not reached their end-of-life and that actually are used by TYPO3.