### PR TITLE
[BUGFIX] Use Composer 2.4 for the unit tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
-          tools: composer:v2
+          tools: composer:v2.4
           extensions: mysqli
           coverage: none
       - name: "Show Composer version"


### PR DESCRIPTION
The TYPO3 Console currently breaks with Composer 2.5.