### PR TITLE
[TASK] Add the `testing` keyword to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,11 @@
 	"description": "Unit testing for TYPO3. Includes PHPUnit and a CLI test runner.",
 	"type": "typo3-cms-extension",
 	"keywords": [
-		"tdd",
-		"unit testing",
 		"phpunit",
-		"typo3"
+		"tdd",
+		"testing",
+		"typo3",
+		"unit testing"
 	],
 	"license": "GPL-2.0-or-later",
 	"authors": [


### PR DESCRIPTION
This causes Composer 2.4 to complain if this package is installed as a production dependency instead of as a development dependency: https://php.watch/articles/composer-prompt-require-dev-dev-packages

Fixes #475